### PR TITLE
feat: MFA account recovery via single-use backup codes

### DIFF
--- a/client/src/app/shell/AppShell.tsx
+++ b/client/src/app/shell/AppShell.tsx
@@ -1,4 +1,4 @@
-import { useEffect } from 'react'
+import { useEffect, useState } from 'react'
 import { NavLink, Outlet, useNavigate } from 'react-router-dom'
 import { useAuth } from '../../features/auth/contexts/AuthContext'
 import { MFA_REQUIRED_EVENT, type MfaRequiredEventDetail } from '../../shared/api/http'
@@ -11,6 +11,9 @@ const navItems = [
 export function AppShell() {
   const { user, signOut } = useAuth()
   const navigate = useNavigate()
+  const [showRecoveryBanner, setShowRecoveryBanner] = useState(() => {
+    return sessionStorage.getItem('pt:recovery_used') === '1'
+  })
 
   useEffect(() => {
     const handleMfaRequired = (event: Event) => {
@@ -74,6 +77,35 @@ export function AppShell() {
         </div>
       </header>
       <main className="app-main">
+        {showRecoveryBanner ? (
+          <div role="alert" style={{
+            background: '#fef3c7',
+            borderBottom: '1px solid #f59e0b',
+            padding: '0.75rem 1rem',
+            display: 'flex',
+            justifyContent: 'space-between',
+            alignItems: 'center',
+            gap: '1rem',
+            fontSize: '0.9rem',
+          }}>
+            <span>
+              <strong>Action required:</strong> You signed in with a recovery code. Your previous authenticator has been
+              removed. <button
+                type="button"
+                onClick={() => navigate('/profile')}
+                style={{ background: 'none', border: 'none', color: '#92400e', cursor: 'pointer', textDecoration: 'underline', padding: 0 }}
+              >Set up a new authenticator</button> to re-enable two-factor authentication.
+            </span>
+            <button
+              type="button"
+              aria-label="Dismiss"
+              onClick={() => { sessionStorage.removeItem('pt:recovery_used'); setShowRecoveryBanner(false); }}
+              style={{ background: 'none', border: 'none', cursor: 'pointer', fontSize: '1.1rem', lineHeight: 1, color: '#92400e' }}
+            >
+              &times;
+            </button>
+          </div>
+        ) : null}
         <Outlet />
       </main>
     </div>

--- a/client/src/features/auth/contexts/AuthContext.tsx
+++ b/client/src/features/auth/contexts/AuthContext.tsx
@@ -67,6 +67,9 @@ interface AuthContextType {
   getToken: () => Promise<string | null>
   resetPassword: (email: string) => Promise<void>
   updatePassword: (newPassword: string) => Promise<void>
+  generateRecoveryCodes: () => Promise<string[]>
+  getRecoveryCodesStatus: () => Promise<{ total: number; remaining: number }>
+  verifyRecoveryCode: (code: string) => Promise<void>
 }
 
 const AuthContext = createContext<AuthContextType | undefined>(undefined)
@@ -325,6 +328,62 @@ export function AuthProvider({ children }: { children: ReactNode }) {
     await refreshMfaState()
   }
 
+  const generateRecoveryCodes = async (): Promise<string[]> => {
+    const token = await getToken()
+    if (!token) throw new Error('Not authenticated')
+
+    const response = await fetch(`${apiBaseUrl}/auth/recovery-codes/generate`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}))
+      throw new Error((body as { message?: string }).message || 'Failed to generate recovery codes')
+    }
+
+    const data = await response.json() as { codes: string[] }
+    return data.codes
+  }
+
+  const getRecoveryCodesStatus = async (): Promise<{ total: number; remaining: number }> => {
+    const token = await getToken()
+    if (!token) throw new Error('Not authenticated')
+
+    const response = await fetch(`${apiBaseUrl}/auth/recovery-codes/status`, {
+      headers: { Authorization: `Bearer ${token}` },
+    })
+
+    if (!response.ok) {
+      throw new Error('Failed to fetch recovery code status')
+    }
+
+    return response.json() as Promise<{ total: number; remaining: number }>
+  }
+
+  const verifyRecoveryCode = async (code: string): Promise<void> => {
+    const token = await getToken()
+    if (!token) throw new Error('Not authenticated')
+
+    const response = await fetch(`${apiBaseUrl}/auth/recovery-codes/use`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ code }),
+    })
+
+    if (!response.ok) {
+      const body = await response.json().catch(() => ({}))
+      throw new Error((body as { message?: string }).message || 'Invalid or already-used recovery code')
+    }
+
+    // Supabase session is still aal1; refresh so downstream state reflects no MFA factors
+    await supabase.auth.refreshSession()
+    await refreshMfaState()
+  }
+
   const signOut = async () => {
     setIsLoading(true)
     try {
@@ -373,6 +432,9 @@ export function AuthProvider({ children }: { children: ReactNode }) {
         getToken,
         resetPassword,
         updatePassword,
+        generateRecoveryCodes,
+        getRecoveryCodesStatus,
+        verifyRecoveryCode
       }}
     >
       {children}

--- a/client/src/features/auth/pages/LoginPage.tsx
+++ b/client/src/features/auth/pages/LoginPage.tsx
@@ -10,6 +10,8 @@ export function LoginPage() {
   const [email, setEmail] = useState('')
   const [password, setPassword] = useState('')
   const [mfaCode, setMfaCode] = useState('')
+  const [recoveryCode, setRecoveryCode] = useState('')
+  const [showRecovery, setShowRecovery] = useState(false)
   const [error, setError] = useState('')
   const [isLoading, setIsLoading] = useState(false)
   
@@ -20,6 +22,7 @@ export function LoginPage() {
     pendingMfaFactors,
     selectPendingMfaFactor,
     verifyMfaSignIn,
+    verifyRecoveryCode,
   } = useAuth()
   const navigate = useNavigate()
   const [searchParams] = useSearchParams()
@@ -71,6 +74,24 @@ export function LoginPage() {
       navigate(redirectTo, { replace: true })
     } catch (error) {
       setError(getErrorMessage(error, 'Failed to verify authenticator code'))
+    } finally {
+      setIsLoading(false)
+    }
+  }
+
+  const handleRecoverySubmit = async (e: React.FormEvent) => {
+    e.preventDefault()
+    setError('')
+    setInfo('')
+    setIsLoading(true)
+
+    try {
+      await verifyRecoveryCode(recoveryCode.trim())
+      // Flag for AppShell to show re-enrollment banner
+      sessionStorage.setItem('pt:recovery_used', '1')
+      navigate(redirectTo, { replace: true })
+    } catch (error) {
+      setError(getErrorMessage(error, 'Invalid or already-used recovery code'))
     } finally {
       setIsLoading(false)
     }
@@ -135,6 +156,69 @@ export function LoginPage() {
             {isLoading ? 'Verifying...' : 'Verify Code'}
           </button>
         </form>
+
+        <div style={{ marginTop: '20px', textAlign: 'center' }}>
+          <button
+            type="button"
+            onClick={() => { setShowRecovery(true); setError(''); setInfo(''); }}
+            disabled={isLoading}
+            style={{ background: 'none', border: 'none', color: '#2563eb', cursor: 'pointer', textDecoration: 'underline', fontSize: '0.9rem' }}
+          >
+            Lost your phone? Use a recovery code
+          </button>
+        </div>
+      </div>
+    )
+  }
+
+  if (isMfaRequired && showRecovery) {
+    return (
+      <div style={{ maxWidth: '400px', margin: '50px auto', padding: '20px' }}>
+        <h1>Account Recovery</h1>
+        <p>Enter one of your saved recovery codes to regain access.</p>
+        <p style={{ fontSize: '0.85rem', color: '#6b7280' }}>
+          Warning: using a recovery code will remove all authenticators from your account.
+          You will need to set up a new authenticator after signing in.
+        </p>
+
+        {info ? <div style={{ color: '#2563eb', marginBottom: '15px' }}>{info}</div> : null}
+
+        <form onSubmit={handleRecoverySubmit}>
+          <div style={{ marginBottom: '15px' }}>
+            <label>Recovery Code:</label>
+            <input
+              type="text"
+              placeholder="xxxx-xxxx-xxxx-xxxx"
+              value={recoveryCode}
+              onChange={(e) => setRecoveryCode(e.target.value)}
+              required
+              disabled={isLoading}
+              autoComplete="off"
+              style={{ width: '100%', padding: '8px', fontFamily: 'monospace' }}
+            />
+          </div>
+
+          {error && <div style={{ color: 'red', marginBottom: '15px' }}>{error}</div>}
+
+          <button
+            type="submit"
+            disabled={isLoading || recoveryCode.trim().length === 0}
+            style={{ width: '100%', padding: '10px', cursor: 'pointer' }}
+          >
+            {isLoading ? 'Verifying...' : 'Use Recovery Code'}
+          </button>
+        </form>
+
+        <div style={{ marginTop: '15px', textAlign: 'center' }}>
+          <button
+            type="button"
+            onClick={() => { setShowRecovery(false); setError(''); }}
+            disabled={isLoading}
+            style={{ background: 'none', border: 'none', color: '#6b7280', cursor: 'pointer', textDecoration: 'underline', fontSize: '0.9rem' }}
+          >
+            Back to authenticator code
+          </button>
+        </div>
       </div>
     )
   }

--- a/client/src/pages/SettingsPage.tsx
+++ b/client/src/pages/SettingsPage.tsx
@@ -8,7 +8,7 @@ const currencyOptions = ['INR', 'USD', 'EUR', 'GBP', 'AED', 'SGD', 'AUD', 'JPY']
 export function ProfilePage() {
   const profileQuery = useProfile()
   const updateProfile = useUpdateProfile()
-  const { mfaFactors, enrollMfa, verifyMfaEnrollment, removeMfaFactor, refreshMfaState } = useAuth()
+  const { mfaFactors, enrollMfa, verifyMfaEnrollment, removeMfaFactor, refreshMfaState, generateRecoveryCodes, getRecoveryCodesStatus } = useAuth()
   const [currency, setCurrency] = useState('INR')
   const [mfaFriendlyName, setMfaFriendlyName] = useState('PocketTracker')
   const [mfaCode, setMfaCode] = useState('')
@@ -21,6 +21,13 @@ export function ProfilePage() {
     secret: string
     uri: string
   } | null>(null)
+  // Recovery codes
+  const [newRecoveryCodes, setNewRecoveryCodes] = useState<string[]>([])
+  const [recoverySaved, setRecoverySaved] = useState(false)
+  const [recoveryStatus, setRecoveryStatus] = useState<{ total: number; remaining: number } | null>(null)
+  const [recoveryBusy, setRecoveryBusy] = useState(false)
+  const [recoveryError, setRecoveryError] = useState('')
+  const [showRegenerateWarning, setShowRegenerateWarning] = useState(false)
 
   const profile = profileQuery.data?.users?.[0]
 
@@ -35,6 +42,14 @@ export function ProfilePage() {
       // Profile page still works even if MFA state refresh fails.
     })
   }, [])
+
+  useEffect(() => {
+    if (mfaFactors.length > 0) {
+      void getRecoveryCodesStatus().then(setRecoveryStatus).catch(() => null)
+    } else {
+      setRecoveryStatus(null)
+    }
+  }, [mfaFactors.length])
 
   if (profileQuery.isLoading) {
     return (
@@ -87,6 +102,16 @@ export function ProfilePage() {
       setPendingEnrollment(null)
       setMfaCode('')
       setMfaSuccess('Two-factor authentication is enabled for your account.')
+      // Auto-generate recovery codes immediately after enrollment
+      try {
+        const codes = await generateRecoveryCodes()
+        setNewRecoveryCodes(codes)
+        setRecoverySaved(false)
+        void getRecoveryCodesStatus().then(setRecoveryStatus).catch(() => null)
+      } catch {
+        // Recovery code generation failure is non-fatal
+        setMfaError('Authenticator enabled, but recovery codes could not be generated. Try regenerating from the Recovery Codes section.')
+      }
     } catch (error: any) {
       setMfaError(error.message || 'Failed to verify authenticator code.')
     } finally {
@@ -102,10 +127,28 @@ export function ProfilePage() {
     try {
       await removeMfaFactor(factorId)
       setMfaSuccess('Authenticator removed from your account.')
+      setRecoveryStatus(null)
     } catch (error: any) {
       setMfaError(error.message || 'Failed to remove authenticator.')
     } finally {
       setIsMfaBusy(false)
+    }
+  }
+
+  async function onRegenerateRecoveryCodes() {
+    setRecoveryError('')
+    setRecoveryBusy(true)
+    setShowRegenerateWarning(false)
+
+    try {
+      const codes = await generateRecoveryCodes()
+      setNewRecoveryCodes(codes)
+      setRecoverySaved(false)
+      void getRecoveryCodesStatus().then(setRecoveryStatus).catch(() => null)
+    } catch (error: any) {
+      setRecoveryError(error.message || 'Failed to regenerate recovery codes.')
+    } finally {
+      setRecoveryBusy(false)
     }
   }
 
@@ -254,6 +297,94 @@ export function ProfilePage() {
           </div>
         ) : null}
       </div>
+
+      {/* Recovery codes section — only shown when MFA is enrolled */}
+      {mfaFactors.length > 0 ? (
+        <div className="table-wrap" style={{ padding: '1rem', maxWidth: '720px', marginTop: '1rem' }}>
+          <h2 style={{ marginTop: 0 }}>Recovery Codes</h2>
+          <p className="muted" style={{ marginTop: 0 }}>
+            Recovery codes let you access your account if you lose your authenticator device.
+            Each code can only be used once.
+          </p>
+
+          {recoveryError ? <p className="error">{recoveryError}</p> : null}
+
+          {/* Status indicator */}
+          {recoveryStatus && newRecoveryCodes.length === 0 ? (
+            <p>
+              <strong>{recoveryStatus.remaining}</strong> of {recoveryStatus.total} codes remaining.
+              {recoveryStatus.remaining <= 3 ? (
+                <span style={{ color: '#dc2626' }}> Running low — consider regenerating.</span>
+              ) : null}
+            </p>
+          ) : null}
+
+          {/* Show newly generated codes (after enrollment or regeneration) */}
+          {newRecoveryCodes.length > 0 ? (
+            <div style={{ display: 'grid', gap: '0.75rem' }}>
+              <p style={{ margin: 0, color: '#dc2626', fontWeight: 500 }}>
+                Save these codes somewhere safe. They will not be shown again.
+              </p>
+              <div style={{
+                display: 'grid',
+                gridTemplateColumns: '1fr 1fr',
+                gap: '0.4rem',
+                padding: '1rem',
+                background: 'var(--color-surface, #f9f9f9)',
+                border: '1px solid var(--color-border, #ddd)',
+                fontFamily: 'monospace',
+                fontSize: '0.9rem',
+              }}>
+                {newRecoveryCodes.map((code) => (
+                  <span key={code}>{code}</span>
+                ))}
+              </div>
+              <label style={{ display: 'flex', gap: '0.5rem', alignItems: 'center', cursor: 'pointer' }}>
+                <input
+                  type="checkbox"
+                  checked={recoverySaved}
+                  onChange={(e) => setRecoverySaved(e.target.checked)}
+                />
+                I have saved these recovery codes in a secure place.
+              </label>
+              <button
+                type="button"
+                disabled={!recoverySaved}
+                onClick={() => setNewRecoveryCodes([])}
+                style={{ maxWidth: '200px' }}
+              >
+                Done
+              </button>
+            </div>
+          ) : (
+            <div style={{ display: 'grid', gap: '0.5rem', maxWidth: '260px' }}>
+              {showRegenerateWarning ? (
+                <>
+                  <p style={{ margin: 0, color: '#dc2626', fontSize: '0.9rem' }}>
+                    This will invalidate all existing codes. Continue?
+                  </p>
+                  <div style={{ display: 'flex', gap: '0.5rem' }}>
+                    <button type="button" disabled={recoveryBusy} onClick={() => void onRegenerateRecoveryCodes()}>
+                      {recoveryBusy ? 'Regenerating...' : 'Yes, regenerate'}
+                    </button>
+                    <button type="button" disabled={recoveryBusy} onClick={() => setShowRegenerateWarning(false)}>
+                      Cancel
+                    </button>
+                  </div>
+                </>
+              ) : (
+                <button
+                  type="button"
+                  disabled={recoveryBusy}
+                  onClick={() => setShowRegenerateWarning(true)}
+                >
+                  Regenerate Recovery Codes
+                </button>
+              )}
+            </div>
+          )}
+        </div>
+      ) : null}
     </section>
   )
 }

--- a/server/controllers/RecoveryCodeController.ts
+++ b/server/controllers/RecoveryCodeController.ts
@@ -1,0 +1,106 @@
+import { Request, Response } from 'express';
+import RecoveryCodeService from '../services/RecoveryCodeService';
+import supabaseClient from '../config/authConfig';
+import UserModel from '../models/UserModel';
+
+const recoveryCodeService = new RecoveryCodeService();
+
+export default class RecoveryCodeController {
+  /**
+   * POST /api/auth/recovery-codes/generate
+   * Requires aal2 (verifyAuth middleware). Returns plaintext codes — shown once.
+   */
+  async generateCodes(req: Request, res: Response) {
+    try {
+      const supabaseId = req.user!.id;
+      const dbUser = await UserModel.findOne({ where: { supabase_id: supabaseId } });
+      if (!dbUser) {
+        res.status(404).json({ message: 'User not found' });
+        return;
+      }
+
+      const codes = await recoveryCodeService.generateCodes(dbUser.get('id') as string);
+      res.json({ codes });
+    } catch (error) {
+      console.error('generateCodes error:', error);
+      res.status(500).json({ message: 'Failed to generate recovery codes' });
+    }
+  }
+
+  /**
+   * GET /api/auth/recovery-codes/status
+   * Requires aal2 (verifyAuth middleware).
+   */
+  async getStatus(req: Request, res: Response) {
+    try {
+      const supabaseId = req.user!.id;
+      const dbUser = await UserModel.findOne({ where: { supabase_id: supabaseId } });
+      if (!dbUser) {
+        res.status(404).json({ message: 'User not found' });
+        return;
+      }
+
+      const status = await recoveryCodeService.getStatus(dbUser.get('id') as string);
+      res.json(status);
+    } catch (error) {
+      console.error('getStatus error:', error);
+      res.status(500).json({ message: 'Failed to fetch recovery code status' });
+    }
+  }
+
+  /**
+   * POST /api/auth/recovery-codes/use
+   * Requires aal1 (verifyAal1Auth middleware). Does NOT require aal2 — this is the recovery path.
+   * On success: marks code used, unenrolls all TOTP factors from Supabase.
+   */
+  async useCode(req: Request, res: Response) {
+    try {
+      const { code } = req.body as { code?: string };
+      if (!code || typeof code !== 'string') {
+        res.status(400).json({ message: 'Recovery code is required' });
+        return;
+      }
+
+      const supabaseId = req.user!.id;
+      const dbUser = await UserModel.findOne({ where: { supabase_id: supabaseId } });
+      if (!dbUser) {
+        res.status(404).json({ message: 'User not found' });
+        return;
+      }
+
+      const valid = await recoveryCodeService.verifyAndUseCode(dbUser.get('id') as string, code);
+      if (!valid) {
+        res.status(400).json({ message: 'Invalid or already-used recovery code' });
+        return;
+      }
+
+      // Unenroll all verified TOTP factors so the lost device can no longer sign in
+      const { data: factorData, error: listError } = await supabaseClient.auth.admin.mfa.listFactors({
+        userId: supabaseId,
+      });
+
+      if (listError) {
+        console.error('listFactors error:', listError);
+        res.status(500).json({ message: 'Failed to fetch MFA factors' });
+        return;
+      }
+
+      const verifiedFactors = (factorData?.factors || []).filter((f) => f.status === 'verified');
+
+      for (const factor of verifiedFactors) {
+        const { error: deleteError } = await supabaseClient.auth.admin.mfa.deleteFactor({
+          userId: supabaseId,
+          id: factor.id,
+        });
+        if (deleteError) {
+          console.error(`Failed to delete factor ${factor.id}:`, deleteError);
+        }
+      }
+
+      res.json({ message: 'Recovery code accepted. All authenticators have been removed. Please enroll a new one.' });
+    } catch (error) {
+      console.error('useCode error:', error);
+      res.status(500).json({ message: 'Failed to process recovery code' });
+    }
+  }
+}

--- a/server/interfaces/MfaRecoveryCode.ts
+++ b/server/interfaces/MfaRecoveryCode.ts
@@ -1,0 +1,8 @@
+export default interface MfaRecoveryCode {
+  id?: string;
+  user_id: string;
+  code_hash: string;
+  used_at?: string | null;
+  readonly createdAt?: string;
+  readonly updatedAt?: string;
+}

--- a/server/middlewares/Middlewares.ts
+++ b/server/middlewares/Middlewares.ts
@@ -105,6 +105,41 @@ export default class Middlewares {
         }
     }
 
+    /**
+     * Like verifyAuth but does NOT enforce aal2. Used exclusively on the recovery-code
+     * /use endpoint, where the session is intentionally aal1 (password-only).
+     */
+    static async verifyAal1Auth(req: Request, res: Response, next: NextFunction) {
+        try {
+            const authHeader = req.headers.authorization;
+
+            if (!authHeader || !authHeader.startsWith("Bearer ")) {
+                res.status(401).json({ message: "Missing or invalid authorization header" });
+                return;
+            }
+
+            const token = authHeader.substring(7);
+            const { data, error } = await supabaseClient.auth.getUser(token);
+
+            if (error || !data.user) {
+                res.status(401).json({ message: "Invalid or expired token" });
+                return;
+            }
+
+            req.user = {
+                id: data.user.id,
+                email: data.user.email || "",
+                first_name: data.user.user_metadata?.first_name,
+                last_name: data.user.user_metadata?.last_name,
+            };
+
+            next();
+        } catch (error) {
+            console.error("verifyAal1Auth error:", error);
+            res.status(401).json({ message: "Authentication failed" });
+        }
+    }
+
     static async notFound(req: Request, res: Response, next: NextFunction) {
         res.status(404).json({ message: 'Not Found' });
     }

--- a/server/models/MfaRecoveryCodeModel.ts
+++ b/server/models/MfaRecoveryCodeModel.ts
@@ -1,0 +1,34 @@
+import { DataTypes } from 'sequelize';
+import { sequelize } from '../config/dbConnection';
+
+const MfaRecoveryCodeModel = sequelize.define('mfa_recovery_code', {
+  id: {
+    type: DataTypes.UUID,
+    defaultValue: DataTypes.UUIDV4,
+    primaryKey: true,
+  },
+  user_id: {
+    type: DataTypes.UUID,
+    allowNull: false,
+    comment: 'References users.id (application user, not supabase_id)',
+  },
+  code_hash: {
+    type: DataTypes.STRING(64),
+    allowNull: false,
+    comment: 'SHA-256 hex digest of the plaintext recovery code',
+  },
+  used_at: {
+    type: DataTypes.DATE,
+    allowNull: true,
+    defaultValue: null,
+  },
+}, {
+  timestamps: true,
+  indexes: [
+    {
+      fields: ['user_id', 'used_at'],
+    },
+  ],
+});
+
+export default MfaRecoveryCodeModel;

--- a/server/package.json
+++ b/server/package.json
@@ -15,7 +15,8 @@
     "build:prod": "npm run build && npm run build:client",
     "test": "echo \"No default test suite configured\"",
     "test:insights": "DOTENV_CONFIG_PATH=\"${ENV_FILE_PATH:-$HOME/adarsh-envs/PocketTracker/server/.env}\" node -r dotenv/config -r ts-node/register tests/insightsService.test.ts",
-    "test:mfa-smoke": "DOTENV_CONFIG_PATH=\"${ENV_FILE_PATH:-$HOME/adarsh-envs/PocketTracker/server/.env}\" node -r dotenv/config -r ts-node/register tests/mfaMultiDeviceSmoke.test.ts"
+    "test:mfa-smoke": "DOTENV_CONFIG_PATH=\"${ENV_FILE_PATH:-$HOME/adarsh-envs/PocketTracker/server/.env}\" node -r dotenv/config -r ts-node/register tests/mfaMultiDeviceSmoke.test.ts",
+    "test:mfa-recovery-smoke": "DOTENV_CONFIG_PATH=\"${ENV_FILE_PATH:-$HOME/adarsh-envs/PocketTracker/server/.env}\" node -r dotenv/config -r ts-node/register tests/mfaRecoveryCodeSmoke.test.ts"
   },
   "author": "aadarshp31",
   "license": "CC-BY-NC-4.0",

--- a/server/routes/recoveryCodeRoute.ts
+++ b/server/routes/recoveryCodeRoute.ts
@@ -1,0 +1,15 @@
+import express from 'express';
+import Middlewares from '../middlewares/Middlewares';
+import RecoveryCodeController from '../controllers/RecoveryCodeController';
+
+const recoveryCodeRoute = express.Router();
+const controller = new RecoveryCodeController();
+
+// Generate / view recovery codes — requires full MFA session (aal2)
+recoveryCodeRoute.post('/generate', Middlewares.verifyAuth, controller.generateCodes.bind(controller));
+recoveryCodeRoute.get('/status', Middlewares.verifyAuth, controller.getStatus.bind(controller));
+
+// Use a recovery code to regain access — only requires password session (aal1)
+recoveryCodeRoute.post('/use', Middlewares.verifyAal1Auth, controller.useCode.bind(controller));
+
+export default recoveryCodeRoute;

--- a/server/server.ts
+++ b/server/server.ts
@@ -13,6 +13,8 @@ import Middlewares from './middlewares/Middlewares';
 import budgetRoute from './routes/budgetRoute';
 import authRoute from './routes/AuthRoutes';
 import insightsRoute from './routes/insightsRoute';
+import recoveryCodeRoute from './routes/recoveryCodeRoute';
+import './models/MfaRecoveryCodeModel'; // ensure table is created on sync
 
 const app = express();
 
@@ -50,6 +52,9 @@ app.get('/api/', async (req: Request, res: Response) => {
 
 // auth endpoints (no authentication required)
 app.use('/api/auth', authRoute);
+
+// Recovery code endpoints — mixed auth (aal1 for /use, aal2 for /generate and /status)
+app.use('/api/auth/recovery-codes', recoveryCodeRoute);
 
 // Protected routes - apply JWT verification middleware
 app.use('/api/users', Middlewares.verifyAuth, userRoute);

--- a/server/services/RecoveryCodeService.ts
+++ b/server/services/RecoveryCodeService.ts
@@ -1,0 +1,77 @@
+import crypto from 'crypto';
+import { Op } from 'sequelize';
+import MfaRecoveryCodeModel from '../models/MfaRecoveryCodeModel';
+
+const TOTAL_CODES = 10;
+const CODE_BYTES = 8; // 64-bit entropy → 16 hex chars → formatted as xxxx-xxxx-xxxx-xxxx
+
+function hashCode(plaintext: string): string {
+  return crypto.createHash('sha256').update(plaintext, 'utf8').digest('hex');
+}
+
+function formatCode(hex: string): string {
+  // hex is 16 chars; split into 4 groups of 4
+  return `${hex.slice(0, 4)}-${hex.slice(4, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}`;
+}
+
+function normalizeCode(input: string): string {
+  return input.replace(/\s/g, '').toLowerCase();
+}
+
+export default class RecoveryCodeService {
+  /**
+   * Delete all existing codes for a user, generate TOTAL_CODES fresh ones,
+   * persist their hashes, and return the plaintext codes (shown once only).
+   */
+  async generateCodes(userId: string): Promise<string[]> {
+    // Remove previous codes atomically
+    await MfaRecoveryCodeModel.destroy({ where: { user_id: userId } });
+
+    const plaintextCodes: string[] = [];
+    const records = [];
+
+    for (let i = 0; i < TOTAL_CODES; i++) {
+      const hex = crypto.randomBytes(CODE_BYTES).toString('hex');
+      const plaintext = formatCode(hex);
+      plaintextCodes.push(plaintext);
+      records.push({ user_id: userId, code_hash: hashCode(normalizeCode(plaintext)) });
+    }
+
+    await MfaRecoveryCodeModel.bulkCreate(records);
+    return plaintextCodes;
+  }
+
+  /**
+   * Verify a recovery code. If valid and unused, mark it as used and return true.
+   * Returns false for unknown or already-used codes.
+   */
+  async verifyAndUseCode(userId: string, code: string): Promise<boolean> {
+    const hash = hashCode(normalizeCode(code));
+
+    const record = await MfaRecoveryCodeModel.findOne({
+      where: {
+        user_id: userId,
+        code_hash: hash,
+        used_at: { [Op.is]: null },
+      },
+    });
+
+    if (!record) {
+      return false;
+    }
+
+    await record.update({ used_at: new Date() });
+    return true;
+  }
+
+  /**
+   * Return total and remaining (unused) code counts for a user.
+   */
+  async getStatus(userId: string): Promise<{ total: number; remaining: number }> {
+    const total = await MfaRecoveryCodeModel.count({ where: { user_id: userId } });
+    const used = await MfaRecoveryCodeModel.count({
+      where: { user_id: userId, used_at: { [Op.not]: null } },
+    });
+    return { total, remaining: total - used };
+  }
+}

--- a/server/tests/mfaRecoveryCodeSmoke.test.ts
+++ b/server/tests/mfaRecoveryCodeSmoke.test.ts
@@ -1,0 +1,189 @@
+/**
+ * MFA Recovery Code Smoke Test
+ *
+ * Verifies the full recovery-code lifecycle end-to-end:
+ *  1. Creates a test user and enrolls TOTP.
+ *  2. Generates recovery codes via the API (simulated via direct service call using admin client).
+ *  3. Signs out and back in with password only (aal1 session).
+ *  4. Uses a recovery code via the /api/auth/recovery-codes/use endpoint.
+ *  5. Verifies all TOTP factors are removed from Supabase.
+ *  6. Verifies the used code is rejected on a second attempt.
+ *  7. Cleans up the test user.
+ *
+ * Usage:
+ *   npm run test:mfa-recovery-smoke
+ */
+
+import assert from 'node:assert/strict'
+import crypto from 'node:crypto'
+import { createClient } from '@supabase/supabase-js'
+
+// ---------------------------------------------------------------------------
+// Minimal TOTP implementation (mirrors mfaMultiDeviceSmoke.test.ts)
+// ---------------------------------------------------------------------------
+
+function decodeBase32(input: string): Buffer {
+  const alphabet = 'ABCDEFGHIJKLMNOPQRSTUVWXYZ234567'
+  const cleaned = input.toUpperCase().replace(/=+$/g, '').replace(/\s+/g, '')
+  let bits = ''
+  for (const char of cleaned) {
+    const idx = alphabet.indexOf(char)
+    if (idx === -1) throw new Error(`Invalid base32 character: ${char}`)
+    bits += idx.toString(2).padStart(5, '0')
+  }
+  const bytes: number[] = []
+  for (let i = 0; i + 8 <= bits.length; i += 8) {
+    bytes.push(parseInt(bits.slice(i, i + 8), 2))
+  }
+  return Buffer.from(bytes)
+}
+
+function generateTotp(secret: string, timestampMs = Date.now(), timeStepSeconds = 30, digits = 6): string {
+  const key = decodeBase32(secret)
+  const counter = Math.floor(timestampMs / 1000 / timeStepSeconds)
+  const counterBuffer = Buffer.alloc(8)
+  counterBuffer.writeBigUInt64BE(BigInt(counter))
+  const hmac = crypto.createHmac('sha1', key).update(counterBuffer).digest()
+  const offset = hmac[hmac.length - 1] & 0x0f
+  const binary =
+    ((hmac[offset] & 0x7f) << 24) |
+    ((hmac[offset + 1] & 0xff) << 16) |
+    ((hmac[offset + 2] & 0xff) << 8) |
+    (hmac[offset + 3] & 0xff)
+  return (binary % 10 ** digits).toString().padStart(digits, '0')
+}
+
+// ---------------------------------------------------------------------------
+// Recovery code helpers — mirrors RecoveryCodeService logic
+// ---------------------------------------------------------------------------
+
+function hashCode(plaintext: string): string {
+  return crypto.createHash('sha256').update(plaintext.replace(/\s/g, '').toLowerCase(), 'utf8').digest('hex')
+}
+
+function formatCode(hex: string): string {
+  return `${hex.slice(0, 4)}-${hex.slice(4, 8)}-${hex.slice(8, 12)}-${hex.slice(12, 16)}`
+}
+
+// ---------------------------------------------------------------------------
+// Main
+// ---------------------------------------------------------------------------
+
+async function run() {
+  const supabaseUrl = process.env.SUPABASE_URL
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE_KEY
+  const anonKey = process.env.SUPABASE_ANON_KEY || process.env.VITE_SUPABASE_ANON_KEY
+  const apiBaseUrl = process.env.API_BASE_URL || 'http://localhost:5001/api'
+
+  assert.ok(supabaseUrl, 'SUPABASE_URL is required')
+  assert.ok(serviceRoleKey, 'SUPABASE_SERVICE_ROLE_KEY is required')
+  assert.ok(anonKey, 'SUPABASE_ANON_KEY or VITE_SUPABASE_ANON_KEY is required')
+
+  const adminClient = createClient(supabaseUrl!, serviceRoleKey!)
+  const userClient = createClient(supabaseUrl!, anonKey!)
+
+  const email = `mfa_recovery_smoke_${Date.now()}@example.com`
+  const password = 'Pocket123!Recovery'
+  let userId: string | null = null
+
+  try {
+    // 1. Create test user
+    const createUser = await adminClient.auth.admin.createUser({ email, password, email_confirm: true })
+    assert.ok(!createUser.error && createUser.data.user, 'Failed to create test user')
+    userId = createUser.data.user.id
+    console.log(`Created test user: ${email} (${userId})`)
+
+    // 2. Sign in and enroll TOTP
+    const signIn1 = await userClient.auth.signInWithPassword({ email, password })
+    assert.ok(!signIn1.error, 'Initial sign-in failed')
+
+    const enroll = await userClient.auth.mfa.enroll({ factorType: 'totp', friendlyName: 'Smoke Test Device' })
+    assert.ok(!enroll.error && enroll.data?.id && enroll.data?.totp?.secret, 'TOTP enrollment failed')
+    const factorId = enroll.data.id
+    const secret = enroll.data.totp.secret
+
+    const verify = await userClient.auth.mfa.challengeAndVerify({ factorId, code: generateTotp(secret) })
+    assert.ok(!verify.error, 'TOTP verification failed')
+
+    // Refresh to aal2
+    await userClient.auth.refreshSession()
+
+    // 3. Generate recovery codes via the server API (user must be aal2)
+    const { data: sessionData } = await userClient.auth.getSession()
+    const aal2Token = sessionData.session?.access_token
+    assert.ok(aal2Token, 'Expected aal2 session token')
+
+    const generateRes = await fetch(`${apiBaseUrl}/auth/recovery-codes/generate`, {
+      method: 'POST',
+      headers: { Authorization: `Bearer ${aal2Token}` },
+    })
+    assert.equal(generateRes.status, 200, `Generate codes returned ${generateRes.status}`)
+    const { codes } = await generateRes.json() as { codes: string[] }
+    assert.equal(codes.length, 10, 'Expected 10 recovery codes')
+    console.log('Generated 10 recovery codes')
+
+    // 4. Check status endpoint
+    const statusRes = await fetch(`${apiBaseUrl}/auth/recovery-codes/status`, {
+      headers: { Authorization: `Bearer ${aal2Token}` },
+    })
+    assert.equal(statusRes.status, 200, `Status returned ${statusRes.status}`)
+    const status = await statusRes.json() as { total: number; remaining: number }
+    assert.equal(status.total, 10)
+    assert.equal(status.remaining, 10)
+    console.log('Status endpoint: 10/10 remaining ✓')
+
+    // 5. Sign out and back in (aal1 only — no MFA step)
+    await userClient.auth.signOut()
+    const signIn2 = await userClient.auth.signInWithPassword({ email, password })
+    assert.ok(!signIn2.error, 'Second sign-in failed')
+
+    const { data: aal1Session } = await userClient.auth.getSession()
+    const aal1Token = aal1Session.session?.access_token
+    assert.ok(aal1Token, 'Expected aal1 session token after re-sign-in')
+    console.log('Re-signed in with password only (aal1)')
+
+    // 6. Use a recovery code
+    const codeToUse = codes[0]
+    const useRes = await fetch(`${apiBaseUrl}/auth/recovery-codes/use`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aal1Token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ code: codeToUse }),
+    })
+    assert.equal(useRes.status, 200, `Use code returned ${useRes.status}: ${await useRes.text()}`)
+    console.log(`Recovery code used successfully: ${codeToUse}`)
+
+    // 7. Verify all TOTP factors are removed
+    const factorsAfter = await adminClient.auth.admin.mfa.listFactors({ userId: userId! })
+    const remainingVerified = (factorsAfter.data?.factors || []).filter((f) => f.status === 'verified')
+    assert.equal(remainingVerified.length, 0, 'Expected all TOTP factors to be unenrolled after recovery')
+    console.log('All TOTP factors removed from Supabase ✓')
+
+    // 8. Verify the used code is rejected on a second attempt
+    const useAgainRes = await fetch(`${apiBaseUrl}/auth/recovery-codes/use`, {
+      method: 'POST',
+      headers: {
+        Authorization: `Bearer ${aal1Token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ code: codeToUse }),
+    })
+    assert.equal(useAgainRes.status, 400, 'Expected 400 for already-used recovery code')
+    console.log('Already-used code correctly rejected with 400 ✓')
+
+    console.log('\nmfaRecoveryCodeSmoke.test.ts: PASS')
+  } catch (error) {
+    console.error('\nmfaRecoveryCodeSmoke.test.ts: FAIL')
+    console.error(error)
+    process.exitCode = 1
+  } finally {
+    if (userId) {
+      await adminClient.auth.admin.deleteUser(userId, true)
+      console.log(`Cleaned up test user ${userId}`)
+    }
+  }
+}
+
+void run()


### PR DESCRIPTION
- Add MfaRecoveryCodeModel (Sequelize) to store SHA-256-hashed codes
- Add RecoveryCodeService: generate (10 codes, xxxx-xxxx-xxxx-xxxx format), verifyAndUseCode, getStatus
- Add RecoveryCodeController: POST /generate, GET /status, POST /use (use-endpoint unenrolls all Supabase TOTP factors after successful use)
- Add verifyAal1Auth middleware (aal1-only, for recovery /use endpoint)
- Register /api/auth/recovery-codes route in server.ts
- Extend AuthContext with generateRecoveryCodes, getRecoveryCodesStatus, verifyRecoveryCode
- LoginPage: add recovery code toggle on MFA screen ('Lost your phone?')
- SettingsPage: auto-show codes after enrollment (must acknowledge), show remaining-code status counter, add Regenerate flow with warning
- AppShell: show dismissible re-enrollment banner after recovery login
- Add mfaRecoveryCodeSmoke.test.ts end-to-end smoke test
- Add npm test:mfa-recovery-smoke script